### PR TITLE
03 systemspec

### DIFF
--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -24,11 +24,27 @@ RSpec.describe "Tasks", type: :system do
       it_behaves_like 'ページへのアクセスが失敗しログイン画面に飛ばされる'
     end
 
-    context 'マイページへアクセスした時' do
+    context 'タスクの詳細ページへアクセスした時' do
       before do
-        visit user_path(user)
+        visit task_path(task)
       end
-      it_behaves_like 'ページへのアクセスが失敗しログイン画面に飛ばされる'
+      it 'タスクの詳細情報が表示される' do
+        expect(page).to have_content task.title
+        expect(current_path).to eq task_path(task)
+      end
+    end
+    
+    context 'タスクの一覧ページへアクセスした時' do
+      before do
+        visit tasks_path
+        task_list = create(:task, 3)
+      end
+      it '全てのユーザーのタスク情報が表示される' do
+        expect(page).to have_content task_list[0].title
+        expect(page).to have_content task_list[1].title
+        expect(page).to have_content task_list[2].title
+        expect(current_path).to eq tasks_path
+      end
     end
   end
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Tasks", type: :system do
         expect(current_path).to eq task_path(task)
       end
     end
-    
+
     context 'タスクの一覧ページへアクセスした時' do
       before do
         visit tasks_path
@@ -56,13 +56,16 @@ RSpec.describe "Tasks", type: :system do
           visit new_task_path
           fill_in 'Title', with: 'new_title'
           fill_in 'Content', with: 'new_content'
-          find("option[value='todo']").select_option
-          fill_in 'Deadline', with: 1.week.from_now
+          select 'doing', from: 'Status'
+          fill_in 'Deadline', with: DateTime.new(2099,12,31,11,59)
           click_button 'Create Task'
         end
         it 'タスクの新規登録が成功する' do
           expect(page).to have_content "Task was successfully created."
           expect(page).to have_content 'new_title'
+          expect(page).to have_content 'new_content'
+          expect(page).to have_content 'doing'
+          expect(page).to have_content '2099/12/31 11:59'
         end
       end
     end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe "Tasks", type: :system do
     end
 
     describe 'タスク削除機能' do
+      let!(:task) { create(:task, user: user) }
       before { login(user) }
       context 'タスクの削除ボタンをクリックした時' do
         before do
@@ -100,6 +101,7 @@ RSpec.describe "Tasks", type: :system do
         it 'タスクの削除が成功する' do
           expect(page).to have_content "Task was successfully destroyed."
           expect(current_path).to eq tasks_path
+          expect(page).not_to have_content task.title
         end
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Users", type: :system do
         it 'ユーザーの新規登録が失敗する' do
           expect(current_path).to eq users_path
           expect(page).to have_content "Email has already been taken"
+          expect(page).to have_field 'Email', with: user.email
         end
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -122,11 +122,15 @@ RSpec.describe "Users", type: :system do
     describe 'マイページ' do
       context 'タスクを作成した時' do
         before do
-          task = create(:task, title: 'new_task', user: user)
+          task = create(:task, title: 'new_task', status: 'doing', user: user)
           visit user_path(user)
         end
         it '新規作成したタスクが表示される' do
           expect(page).to have_content 'new_task'
+          expect(page).to have_content 'doing'
+          expect(page).to have_content 'Show'
+          expect(page).to have_content 'Edit'
+          expect(page).to have_content 'Destroy'
         end
       end
     end


### PR DESCRIPTION
* 新規ユーザー登録時失敗時に画面に入力情報が残っていることの確認
* 新規作成したタスクに加え、show,edit,destroyへのリンクも画面にあることの確認
* タスク詳細ページへアクセスした時、タスク一覧ページへアクセスしたときのcontextを追加
* [タスクの新規登録が成功する]項目にて、全ての入力要素が表示されていることの確認
* [タスクの削除が成功する]項目にて、指定のタスクが残っていないことの確認
以上、五つの項目において修正、追加を行いました。